### PR TITLE
Increase default max_connections to 1024

### DIFF
--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -5,7 +5,7 @@ VOLUME ["/var/lib/mysql", "/snapshots"]
 # Set default charset to UTF-8
 COPY mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
-# Set default charset to UTF-8
+# Set default max_connections to 1024
 COPY mysqld_max_connections.cnf /etc/mysql/conf.d/mysqld_max_connections.cnf
 
 # Point-in-time backup script with backup rotation

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -5,6 +5,9 @@ VOLUME ["/var/lib/mysql", "/snapshots"]
 # Set default charset to UTF-8
 COPY mysqld_charset.cnf /etc/mysql/conf.d/mysqld_charset.cnf
 
+# Set default charset to UTF-8
+COPY mysqld_max_connections.cnf /etc/mysql/conf.d/mysqld_max_connections.cnf
+
 # Point-in-time backup script with backup rotation
 COPY backup.sh /usr/local/bin/
 

--- a/5.7/mysqld_max_connections.cnf
+++ b/5.7/mysqld_max_connections.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+max_connections=1024


### PR DESCRIPTION
Default `max_connections` value is set to 151 and may cause issues when scaling applications using the mysql addon.
https://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html#sysvar_max_connections